### PR TITLE
Better errors and DX fixes

### DIFF
--- a/flint/src/app/app.rs
+++ b/flint/src/app/app.rs
@@ -31,10 +31,17 @@ pub struct App {
 #[derive(Parser, Clone)]
 #[command(version, about, long_about = None, disable_help_subcommand = true, disable_help_flag = true)]
 pub struct AppArgs {
+    #[clap(long, global = false)]
+    pub plugins_dir: Option<String>,
+
+    #[clap(long, global = false)]
+    pub config_path: Option<String>,
+
+    #[clap(long, default_value_t = false, global = false)]
+    pub no_install: bool,
+
     #[command(subcommand)]
     pub command: Option<AppWidgetArgs>,
-    // #[clap(short, long)]
-    // help: bool,
 }
 
 #[derive(Subcommand, Clone)]

--- a/flint/src/app/app.rs
+++ b/flint/src/app/app.rs
@@ -5,8 +5,8 @@ use super::install::{InstallArgs, InstallWidget};
 use super::test::{TestArgs, TestWidget};
 use super::AppWidget;
 use super::{AppError, AppResult};
+use crate::error;
 use crate::util::handle_key_events;
-use crate::widgets::logs::{add_log, LogKind};
 use clap::{Parser, Subcommand};
 use crossterm::event;
 use crossterm::event::KeyCode;
@@ -142,7 +142,7 @@ impl WidgetRef for App {
         ui!((area, buf) => {
             {
                 &self.error.as_ref().map(|err| {
-                    add_log(LogKind::Error, err.clone());
+                    error!("Error occurred: {}", err);
                     Some(widget!({ Popup::new(err.as_str(), title: format!("Error occurred")) }))
                 })
             }
@@ -150,4 +150,13 @@ impl WidgetRef for App {
 
         self.active_widget.render_ref(area, buf);
     }
+}
+
+#[macro_export]
+macro_rules! cmd {
+    ($program:expr, $($arg:expr),* $(,)?) => {{
+        let mut command = Command::new($program);
+        $(command.arg($arg);)*
+        command
+    }};
 }

--- a/flint/src/app/app.rs
+++ b/flint/src/app/app.rs
@@ -155,7 +155,7 @@ impl WidgetRef for App {
 #[macro_export]
 macro_rules! cmd {
     ($program:expr, $($arg:expr),* $(,)?) => {{
-        let mut command = Command::new($program);
+        let mut command = std::process::Command::new($program);
         $(command.arg($arg);)*
         command
     }};

--- a/flint/src/app/generate.rs
+++ b/flint/src/app/generate.rs
@@ -1,7 +1,8 @@
 use super::{AppResult, AppWidget};
 use crate::{
-    success,
+    get_flag, info, success,
     util::{
+        get_language_map,
         plugin::{self, Plugin},
         toml::Config,
     },
@@ -46,7 +47,8 @@ impl GenerateWidget {
 
 impl AppWidget for GenerateWidget {
     fn setup(&mut self) -> AppResult<()> {
-        let toml = Arc::new(Config::load(PathBuf::from("./flint.toml")).unwrap());
+        let config_path = get_flag!(config_path);
+        let toml = Arc::new(Config::load(config_path).unwrap());
         let mut plugin_ids = Vec::new();
         plugin_ids.extend(toml.rules.keys());
         // plugin_ids.extend(toml.tests.keys());
@@ -70,7 +72,7 @@ impl AppWidget for GenerateWidget {
                     Ok(res) => {
                         // TODO: Ask user if we want to overwrite files
                         for (file_name, contents) in res {
-                            let flint_path = Path::new("./.flint");
+                            let flint_path = get_flag!(current_dir).join(".flint");
                             fs::create_dir_all(&flint_path).unwrap();
                             std::fs::write(flint_path.join(file_name), contents).unwrap();
                         }

--- a/flint/src/app/generate.rs
+++ b/flint/src/app/generate.rs
@@ -1,13 +1,15 @@
 use super::{AppResult, AppWidget};
 use crate::{
+    success,
     util::{
         plugin::{self, Plugin},
         toml::Config,
     },
-    widgets::logs::{add_log, LogKind, LogsWidget},
+    widgets::logs::LogsWidget,
 };
 use clap::Parser;
 use flint_macros::ui;
+use log::error;
 use ratatui::prelude::*;
 use ratatui::widgets::WidgetRef;
 use std::{
@@ -72,13 +74,10 @@ impl AppWidget for GenerateWidget {
                             fs::create_dir_all(&flint_path).unwrap();
                             std::fs::write(flint_path.join(file_name), contents).unwrap();
                         }
-                        add_log(
-                            LogKind::Success,
-                            format!("Generated {} config successfully", plugin.details.id),
-                        );
+                        success!("Generated {} config successfully", plugin.details.id)
                     }
                     Err(err) => {
-                        add_log(LogKind::Error, err.to_string());
+                        error!("Error occurred: {}", err);
                     }
                 }
             });

--- a/flint/src/app/generate.rs
+++ b/flint/src/app/generate.rs
@@ -71,8 +71,8 @@ impl AppWidget for GenerateWidget {
                 match result {
                     Ok(res) => {
                         // TODO: Ask user if we want to overwrite files
+                        let flint_path = get_flag!(current_dir).join(".flint");
                         for (file_name, contents) in res {
-                            let flint_path = get_flag!(current_dir).join(".flint");
                             fs::create_dir_all(&flint_path).unwrap();
                             std::fs::write(flint_path.join(file_name), contents).unwrap();
                         }

--- a/flint/src/app/init.rs
+++ b/flint/src/app/init.rs
@@ -1,7 +1,7 @@
 use super::{AppError, AppResult, AppWidget};
 use crate::{
+    info,
     util::{handle_key_events, lang::Language, toml::Config},
-    widgets::logs::{add_log, LogKind},
 };
 use clap::Parser;
 use crossterm::event::{Event, KeyCode};
@@ -107,10 +107,7 @@ impl<'a> WidgetRef for InitWidget<'a> {
 impl<'a> AppWidget for InitWidget<'a> {
     fn setup(&mut self) -> AppResult<()> {
         self.cwd = std::env::current_dir()?;
-        add_log(
-            LogKind::Info,
-            format!("Determined current directory: {}", self.cwd.display()),
-        );
+        info!("Determined current directory: {}", self.cwd.display());
 
         self.langs = crate::util::detect_languages(self.cwd.to_str().unwrap());
 

--- a/flint/src/app/init.rs
+++ b/flint/src/app/init.rs
@@ -1,6 +1,6 @@
 use super::{AppError, AppResult, AppWidget};
 use crate::{
-    info,
+    get_flag, info,
     util::{handle_key_events, lang::Language, toml::Config},
 };
 use clap::Parser;
@@ -21,7 +21,6 @@ pub struct InitWidget<'a> {
     created_config: bool,
     config_exists: bool,
     args: InitWidgetArgs,
-    cwd: PathBuf,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -39,7 +38,6 @@ impl<'a> InitWidget<'a> {
             created_config: false,
             config_exists: false,
             args,
-            cwd: std::env::current_dir().unwrap_or_default(),
         }
     }
 }
@@ -106,12 +104,12 @@ impl<'a> WidgetRef for InitWidget<'a> {
 
 impl<'a> AppWidget for InitWidget<'a> {
     fn setup(&mut self) -> AppResult<()> {
-        self.cwd = std::env::current_dir()?;
-        info!("Determined current directory: {}", self.cwd.display());
+        let cwd = get_flag!(current_dir);
+        info!("Determined current directory: {}", cwd.display());
 
-        self.langs = crate::util::detect_languages(self.cwd.to_str().unwrap());
+        self.langs = crate::util::detect_languages(cwd.to_str().unwrap());
 
-        let config_path = std::path::Path::new(&self.cwd).join("flint.toml");
+        let config_path = std::path::Path::new(&cwd).join("flint.toml");
         if config_path.exists() {
             self.config_exists = true;
         }

--- a/flint/src/app/install.rs
+++ b/flint/src/app/install.rs
@@ -6,7 +6,7 @@ use crate::util::plugin::download::download_plugins_from_config;
 use crate::util::toml::Config;
 use crate::util::{handle_key_events, handle_mouse_event};
 use crate::widgets::logs::{LogsState, LogsWidget};
-use crate::{error, success};
+use crate::{error, get_flag, success, warn};
 use clap::Parser;
 use crossterm::event::{KeyCode, MouseEventKind};
 use threadpool::ThreadPool;
@@ -66,7 +66,12 @@ impl InstallWidget {
 
 impl AppWidget for InstallWidget {
     fn setup(&mut self) -> AppResult<()> {
-        let toml = Config::load(std::env::current_dir().unwrap().join("flint.toml")).unwrap();
+        if *get_flag!(no_install) {
+            warn!("Skipping installation of plugins due to --no-install flag");
+            return Ok(());
+        };
+
+        let toml = Config::load(get_flag!(config_path)).unwrap();
         let toml_clone = toml.clone();
         let pool = self.pool.as_ref().unwrap();
         pool.execute(move || {

--- a/flint/src/app/install.rs
+++ b/flint/src/app/install.rs
@@ -5,7 +5,8 @@ use std::time::Duration;
 use crate::util::plugin::download::download_plugins_from_config;
 use crate::util::toml::Config;
 use crate::util::{handle_key_events, handle_mouse_event};
-use crate::widgets::logs::{add_log, LogKind, LogsState, LogsWidget};
+use crate::widgets::logs::{LogsState, LogsWidget};
+use crate::{error, success};
 use clap::Parser;
 use crossterm::event::{KeyCode, MouseEventKind};
 use threadpool::ThreadPool;
@@ -71,8 +72,8 @@ impl AppWidget for InstallWidget {
         pool.execute(move || {
             std::thread::sleep(Duration::from_secs(10));
             match download_plugins_from_config(&toml_clone) {
-                Ok(_) => add_log(LogKind::Success, "Plugins downloaded successfully".into()),
-                Err(e) => add_log(LogKind::Error, format!("Error downloading plugins: {}", e)),
+                Ok(_) => success!("Plugins downloaded successfully"),
+                Err(e) => error!("Error downloading plugins: {}", e),
             }
         });
         Ok(())
@@ -101,7 +102,6 @@ impl AppWidget for InstallWidget {
 
         handle_mouse_event(event.clone(), |mouse_event| match mouse_event {
             MouseEventKind::ScrollUp => {
-                add_log(LogKind::Info, "Scroll up".to_string());
                 self.logs_state.borrow_mut().scroll_up(1);
                 Ok(())
             }

--- a/flint/src/app/mod.rs
+++ b/flint/src/app/mod.rs
@@ -63,3 +63,13 @@ impl From<Box<dyn ErrorTrait>> for AppError {
 
 // Create type alias for Result with AppError as default error type
 pub type AppResult<T> = Result<T, AppError>;
+
+// Macro to create AppError::Err with format string
+#[macro_export]
+macro_rules! app_err {
+    ($($arg:tt)*) => {{
+        let error_msg = format!($($arg)*);
+        $crate::error!("{}", error_msg);
+        $crate::app::AppError::Err(error_msg)
+    }};
+}

--- a/flint/src/app/mod.rs
+++ b/flint/src/app/mod.rs
@@ -15,6 +15,19 @@ use std::sync::mpsc::Sender;
 use thiserror::Error;
 use threadpool::ThreadPool;
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
+pub static NON_INTERACTIVE: AtomicBool = AtomicBool::new(false);
+
+// Helper functions to interact with the global flag
+pub fn set_non_interactive(value: bool) {
+    NON_INTERACTIVE.store(value, Ordering::SeqCst);
+}
+
+pub fn get_non_interactive() -> bool {
+    NON_INTERACTIVE.load(Ordering::SeqCst)
+}
+
 pub trait AppWidget: WidgetRef {
     fn setup(&mut self) -> AppResult<()> {
         Ok(())

--- a/flint/src/app/mod.rs
+++ b/flint/src/app/mod.rs
@@ -15,19 +15,6 @@ use std::sync::mpsc::Sender;
 use thiserror::Error;
 use threadpool::ThreadPool;
 
-use std::sync::atomic::{AtomicBool, Ordering};
-
-pub static NON_INTERACTIVE: AtomicBool = AtomicBool::new(false);
-
-// Helper functions to interact with the global flag
-pub fn set_non_interactive(value: bool) {
-    NON_INTERACTIVE.store(value, Ordering::SeqCst);
-}
-
-pub fn get_non_interactive() -> bool {
-    NON_INTERACTIVE.load(Ordering::SeqCst)
-}
-
 pub trait AppWidget: WidgetRef {
     fn setup(&mut self) -> AppResult<()> {
         Ok(())

--- a/flint/src/app/test.rs
+++ b/flint/src/app/test.rs
@@ -12,7 +12,7 @@ use std::{
 use threadpool::ThreadPool;
 
 use crate::{
-    cmd, error, info, success,
+    cmd, error, get_flag, info, success,
     util::{
         handle_key_events, handle_mouse_event,
         plugin::{self, Plugin, PluginKind},
@@ -60,7 +60,7 @@ impl TestWidget {
 
 impl AppWidget for TestWidget {
     fn setup(&mut self) -> AppResult<()> {
-        let toml = Arc::new(Config::load(PathBuf::from("./flint.toml")).unwrap());
+        let toml = Arc::new(Config::load(get_flag!(config_path)).unwrap());
         let plugins = plugin::list_from_config(&toml);
 
         let run_plugins: Vec<&Plugin> = plugins

--- a/flint/src/app/test.rs
+++ b/flint/src/app/test.rs
@@ -12,7 +12,7 @@ use std::{
 use threadpool::ThreadPool;
 
 use crate::{
-    error, info, success,
+    cmd, error, info, success,
     util::{
         handle_key_events, handle_mouse_event,
         plugin::{self, Plugin, PluginKind},
@@ -141,8 +141,6 @@ impl AppWidget for TestWidget {
                                                 });
                                             }
                                         }
-
-                                        // fs::create_dir_all(&flint_path).unwrap();
 
                                         match std::fs::write(flint_path.join(&file_name), contents)
                                         {

--- a/flint/src/main.rs
+++ b/flint/src/main.rs
@@ -1,5 +1,8 @@
+use std::path::Path;
+
 use app::{App, AppArgs};
 use clap::Parser;
+use util::flags::handle_global_flags;
 
 pub mod app;
 pub mod util;
@@ -9,6 +12,8 @@ fn main() {
     let args: Vec<String> = std::env::args().collect();
 
     let app_args = AppArgs::parse_from(&args);
+
+    handle_global_flags(&app_args);
 
     // #[cfg(not(debug_assertions))]
     {

--- a/flint/src/main.rs
+++ b/flint/src/main.rs
@@ -19,6 +19,7 @@ fn main() {
         let subcommand = args.get(1).unwrap();
 
         if ["test", "install"].contains(&subcommand.as_str()) {
+            app::set_non_interactive(true);
             let mut non_interactive_widget: Box<dyn AppWidget> = match app_args.command.unwrap() {
                 AppWidgetArgs::Install(args) => Box::new(InstallWidget::new(args)),
                 AppWidgetArgs::Test(args) => Box::new(TestWidget::new(args)),

--- a/flint/src/main.rs
+++ b/flint/src/main.rs
@@ -10,7 +10,7 @@ fn main() {
 
     let app_args = AppArgs::parse_from(&args);
 
-    #[cfg(not(debug_assertions))]
+    // #[cfg(not(debug_assertions))]
     {
         use app::{
             help::HelpWidget, install::InstallWidget, test::TestWidget, AppWidget, AppWidgetArgs,
@@ -19,7 +19,7 @@ fn main() {
         let subcommand = args.get(1).unwrap();
 
         if ["test", "install"].contains(&subcommand.as_str()) {
-            app::set_non_interactive(true);
+            set_flag!(non_interactive, true);
             let mut non_interactive_widget: Box<dyn AppWidget> = match app_args.command.unwrap() {
                 AppWidgetArgs::Install(args) => Box::new(InstallWidget::new(args)),
                 AppWidgetArgs::Test(args) => Box::new(TestWidget::new(args)),

--- a/flint/src/util/flags.rs
+++ b/flint/src/util/flags.rs
@@ -1,30 +1,73 @@
-use std::sync::atomic::AtomicBool;
+use std::{
+    path::{Path, PathBuf},
+    sync::{LazyLock, RwLock},
+};
+
+use crate::app::AppArgs;
 
 pub struct Flags {
-    pub non_interactive: AtomicBool,
+    pub non_interactive: bool,
+    pub plugins_dir: PathBuf,
+    pub config_path: PathBuf,
+    pub current_dir: PathBuf,
+    pub no_install: bool,
 }
 
-// Create a static global instance
-pub static GLOBAL_FLAGS: Flags = Flags {
-    non_interactive: AtomicBool::new(false),
-};
+// Create a static global instance with RwLock
+pub static GLOBAL_FLAGS: LazyLock<RwLock<Flags>> = LazyLock::new(|| {
+    RwLock::new(Flags {
+        non_interactive: false,
+        plugins_dir: crate::util::plugin::dir(),
+        config_path: std::env::current_dir().unwrap().join("flint.toml"),
+        current_dir: std::env::current_dir().unwrap(),
+        no_install: false,
+    })
+});
 
 #[macro_export]
 macro_rules! get_flag {
     ($name:ident) => {{
-        use std::sync::atomic::Ordering;
         use $crate::util::flags::GLOBAL_FLAGS;
 
-        GLOBAL_FLAGS.$name.load(Ordering::SeqCst)
+        // Access the flag value through the RwLock read guard
+        &GLOBAL_FLAGS.read().unwrap().$name
     }};
 }
 
 #[macro_export]
 macro_rules! set_flag {
     ($name:ident, $value:expr) => {{
-        use std::sync::atomic::Ordering;
         use $crate::util::flags::GLOBAL_FLAGS;
 
-        GLOBAL_FLAGS.$name.store($value, Ordering::SeqCst)
+        // Acquire a write lock to safely modify the flag
+        let mut flags = GLOBAL_FLAGS.write().unwrap();
+        flags.$name = $value;
     }};
+}
+
+pub fn handle_global_flags(app_args: &AppArgs) {
+    if let Some(ref plugins_dir) = app_args.plugins_dir {
+        let path = Path::new(plugins_dir);
+        let plugins_path = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir().unwrap().join(&path)
+        };
+        set_flag!(plugins_dir, plugins_path);
+    }
+
+    if let Some(ref config_path) = app_args.config_path {
+        let path = Path::new(config_path);
+        let config_path = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir().unwrap().join(&path)
+        };
+        // Update the current_dir based on the config path's parent directory
+        let current_dir = config_path.parent().unwrap_or(Path::new("")).to_path_buf();
+        set_flag!(current_dir, current_dir);
+        set_flag!(config_path, config_path);
+    }
+
+    set_flag!(no_install, app_args.no_install);
 }

--- a/flint/src/util/flags.rs
+++ b/flint/src/util/flags.rs
@@ -1,0 +1,30 @@
+use std::sync::atomic::AtomicBool;
+
+pub struct Flags {
+    pub non_interactive: AtomicBool,
+}
+
+// Create a static global instance
+pub static GLOBAL_FLAGS: Flags = Flags {
+    non_interactive: AtomicBool::new(false),
+};
+
+#[macro_export]
+macro_rules! get_flag {
+    ($name:ident) => {{
+        use std::sync::atomic::Ordering;
+        use $crate::util::flags::GLOBAL_FLAGS;
+
+        GLOBAL_FLAGS.$name.load(Ordering::SeqCst)
+    }};
+}
+
+#[macro_export]
+macro_rules! set_flag {
+    ($name:ident, $value:expr) => {{
+        use std::sync::atomic::Ordering;
+        use $crate::util::flags::GLOBAL_FLAGS;
+
+        GLOBAL_FLAGS.$name.store($value, Ordering::SeqCst)
+    }};
+}

--- a/flint/src/util/logs.rs
+++ b/flint/src/util/logs.rs
@@ -47,7 +47,7 @@ pub fn add_log(kind: LogKind, message: String) {
     let is_non_interactive = get_flag!(non_interactive);
 
     let log = format!("{} {}", prefix, message);
-    if is_non_interactive {
+    if *is_non_interactive {
         println!("{}", log);
     }
     writeln!(file, "{}", log).unwrap();

--- a/flint/src/util/logs.rs
+++ b/flint/src/util/logs.rs
@@ -1,5 +1,7 @@
 use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
+use crate::get_flag;
+
 #[derive(Copy, Clone, Debug, Default)]
 pub enum LogKind {
     #[default]
@@ -42,7 +44,7 @@ pub fn add_log(kind: LogKind, message: String) {
         LogKind::Debug => "[debug]:",
     };
 
-    let is_non_interactive = crate::app::get_non_interactive();
+    let is_non_interactive = get_flag!(non_interactive);
 
     let log = format!("{} {}", prefix, message);
     if is_non_interactive {

--- a/flint/src/util/logs.rs
+++ b/flint/src/util/logs.rs
@@ -1,0 +1,90 @@
+use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+#[derive(Copy, Clone, Debug, Default)]
+pub enum LogKind {
+    #[default]
+    Info,
+    Success,
+    Error,
+    Warn,
+    Debug,
+}
+
+pub static LOGS: RwLock<Vec<(LogKind, String)>> = RwLock::new(vec![]);
+
+pub fn get_logs() -> Result<
+    RwLockReadGuard<'static, Vec<(LogKind, String)>>,
+    std::sync::PoisonError<RwLockReadGuard<'static, Vec<(LogKind, String)>>>,
+> {
+    LOGS.read()
+}
+
+pub fn get_logs_mut() -> Result<
+    RwLockWriteGuard<'static, Vec<(LogKind, String)>>,
+    std::sync::PoisonError<RwLockWriteGuard<'static, Vec<(LogKind, String)>>>,
+> {
+    LOGS.write()
+}
+
+pub fn add_log(kind: LogKind, message: String) {
+    use std::fs::OpenOptions;
+    use std::io::Write;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("logs.txt")
+        .unwrap();
+    let prefix = match kind {
+        LogKind::Info => "[info]:",
+        LogKind::Success => "[success]:",
+        LogKind::Error => "[error]:",
+        LogKind::Warn => "[warn]:",
+        LogKind::Debug => "[debug]:",
+    };
+    let log = format!("{} {}", prefix, message);
+    writeln!(file, "{}", log).unwrap();
+    get_logs_mut().unwrap().push((kind, log));
+}
+
+#[macro_export]
+macro_rules! log {
+    ($kind:expr, $($arg:tt)*) => {{
+        let message = format!($($arg)*);
+        $crate::util::logs::add_log($kind, message);
+    }};
+}
+
+#[macro_export]
+macro_rules! info {
+    ($($arg:tt)*) => {{
+        $crate::log!(crate::util::logs::LogKind::Info, $($arg)*);
+    }};
+}
+
+#[macro_export]
+macro_rules! warn {
+    ($($arg:tt)*) => {{
+        $crate::log!(crate::util::logs::LogKind::Warn, $($arg)*);
+    }};
+}
+
+#[macro_export]
+macro_rules! error {
+    ($($arg:tt)*) => {{
+        $crate::log!(crate::util::logs::LogKind::Error, $($arg)*);
+    }};
+}
+
+#[macro_export]
+macro_rules! debug {
+    ($($arg:tt)*) => {{
+        $crate::log!(crate::util::logs::LogKind::Debug, $($arg)*);
+    }};
+}
+
+#[macro_export]
+macro_rules! success {
+    ($($arg:tt)*) => {{
+        $crate::log!(crate::util::logs::LogKind::Success, $($arg)*);
+    }};
+}

--- a/flint/src/util/logs.rs
+++ b/flint/src/util/logs.rs
@@ -41,7 +41,13 @@ pub fn add_log(kind: LogKind, message: String) {
         LogKind::Warn => "[warn]:",
         LogKind::Debug => "[debug]:",
     };
+
+    let is_non_interactive = crate::app::get_non_interactive();
+
     let log = format!("{} {}", prefix, message);
+    if is_non_interactive {
+        println!("{}", log);
+    }
     writeln!(file, "{}", log).unwrap();
     get_logs_mut().unwrap().push((kind, log));
 }

--- a/flint/src/util/mod.rs
+++ b/flint/src/util/mod.rs
@@ -1,6 +1,7 @@
 use crossterm::event::{Event, KeyCode, KeyEvent};
 
 pub mod lang;
+pub mod logs;
 pub mod plugin;
 pub mod toml;
 

--- a/flint/src/util/mod.rs
+++ b/flint/src/util/mod.rs
@@ -1,5 +1,6 @@
 use crossterm::event::{Event, KeyCode, KeyEvent};
 
+pub mod flags;
 pub mod lang;
 pub mod logs;
 pub mod plugin;

--- a/flint/src/util/plugin/download.rs
+++ b/flint/src/util/plugin/download.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use crate::app::AppResult;
 use crate::util::plugin;
 use crate::util::toml::Config;
-use crate::{app_err, error};
+use crate::{app_err, error, get_flag};
 use crate::{cmd, info};
 use crate::{success, warn};
 
@@ -23,7 +23,7 @@ pub fn clone_plugin_folders(
     );
 
     // Determine final destination path
-    let final_dest_path = plugin::dir();
+    let final_dest_path = get_flag!(plugins_dir);
 
     info!("Downloading plugins to: {}", final_dest_path.display());
 

--- a/flint/src/util/plugin/download.rs
+++ b/flint/src/util/plugin/download.rs
@@ -3,9 +3,12 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use crate::app::AppResult;
 use crate::util::plugin;
 use crate::util::toml::Config;
-use crate::widgets::logs::{add_log, LogKind};
+use crate::{app_err, error};
+use crate::{cmd, info};
+use crate::{success, warn};
 
 use super::PluginKind;
 
@@ -13,144 +16,94 @@ pub fn clone_plugin_folders(
     repo_url: &str,
     plugin_kind: PluginKind,
     plugin_ids: Vec<&String>,
-) -> Result<PathBuf, Box<dyn Error>> {
-    add_log(
-        LogKind::Info,
-        format!(
-            "Starting plugin clone process for {} plugins",
-            plugin_kind.to_string()
-        ),
+) -> AppResult<PathBuf> {
+    info!(
+        "Starting plugin clone process for {} plugins",
+        plugin_kind.to_string()
     );
 
     // Determine final destination path
     let final_dest_path = plugin::dir();
 
-    add_log(
-        LogKind::Info,
-        format!("Downloading plugins to: {}", final_dest_path.display()),
-    );
+    info!("Downloading plugins to: {}", final_dest_path.display());
 
     // Create a temporary directory for git operations
+    // TODO: Use ProjDirs crate here instead of std::env::temp_dir()
     let temp_path = std::env::temp_dir().join("flint-plugins-temp");
-    add_log(
-        LogKind::Info,
-        format!("Setting up temporary directory at: {}", temp_path.display()),
-    );
 
     // Create temporary directory
     fs::create_dir_all(&temp_path)?;
 
-    add_log(
-        LogKind::Info,
-        format!("Created temporary directory: {}", temp_path.display()),
-    );
-
     // Create the kind subfolder
     let kind_str = &plugin_kind.to_string();
     let kind_path = final_dest_path.join(kind_str);
-    add_log(
-        LogKind::Info,
-        format!("Plugin type directory: {}", kind_path.display()),
-    );
 
     // Make sure the final plugin type directory exists
     fs::create_dir_all(&kind_path)?;
-    add_log(
-        LogKind::Info,
-        format!("Created plugin type directory: {}", kind_path.display()),
-    );
 
     // Check if git is installed and available
-    add_log(LogKind::Info, "Checking if git is installed".to_string());
-    let git_check = Command::new("git").arg("--help").output();
+    info!("Checking if git is installed");
+    let git_check = cmd!["git", "--help"].output().map_err(|e| {
+        app_err!(
+            "Git is not instaled on this system or not in PATH.\nError message: {}",
+            e
+        )
+    })?;
 
-    match git_check {
-        Ok(output) => {
-            if !output.status.success() {
-                add_log(
-                    LogKind::Error,
-                    "Git command failed. Is git installed correctly?".to_string(),
-                );
-                return Err("Git is not available or not working properly".into());
-            }
-            add_log(LogKind::Info, "Git is available and working".to_string());
-        }
-        Err(_) => {
-            add_log(
-                LogKind::Error,
-                "Could not execute git command. Is git installed?".to_string(),
-            );
-            return Err("Git is not installed or not in PATH".into());
-        }
+    if !git_check.status.success() {
+        return Err(app_err!("Git is not available or not working properly"));
     }
 
-    add_log(
-        LogKind::Info,
-        format!("Cloning repository metadata from {}", repo_url),
-    );
+    info!("Cloning repository metadata from {}", repo_url);
 
     // Do git operations in the temporary path
-    let mut cmd = Command::new("git");
-    let cmd = cmd
-        .arg("clone")
-        .arg("--filter=blob:none")
-        .arg("--sparse")
-        .arg(repo_url)
-        .arg(&temp_path);
+    // Define a helper macro for creating commands
 
-    add_log(
-        LogKind::Info,
-        format!("Executing git clone with sparse checkout filter"),
-    );
+    let output = cmd![
+        "git",
+        "clone",
+        "--filter=blob:none",
+        "--sparse",
+        repo_url,
+        &temp_path
+    ]
+    .output()?;
 
-    let output = cmd.output()?;
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     let status = output.status;
 
-    if !stdout.is_empty() {
-        add_log(LogKind::Info, format!("[git clone]: {}", stdout));
-    }
+    if !status.success() {
+        info!(
+            "Cleaning up temporary directory after failed clone: {}",
+            temp_path.display()
+        );
+        fs::remove_dir_all(&temp_path).map_err(|e| {
+            app_err!("Failed to remove temporary directory: {}", e);
+        });
 
-    if !stderr.is_empty() {
-        add_log(LogKind::Error, format!("[git clone]: {}", stderr));
+        return Err(app_err!(
+            "Failed to clone repository.\n Git Clone output: {}",
+            stderr
+        ));
     }
 
     if !status.success() {
         // Clean up the temporary directory if clone fails
-        add_log(
-            LogKind::Info,
-            format!(
-                "Cleaning up temporary directory after failed clone: {}",
-                temp_path.display()
-            ),
-        );
-        let _ = fs::remove_dir_all(&temp_path);
-        return Err("Failed to clone repository".into());
+        return Err(app_err!("Failed to clone repository"));
     }
-
-    add_log(
-        LogKind::Info,
-        "Repository cloned successfully, setting up sparse checkout".to_string(),
-    );
 
     let mut sparse_paths = Vec::new();
     for id in &plugin_ids {
         sparse_paths.push(format!("flint-plugins/{}/{}", kind_str, id));
     }
 
-    add_log(
-        LogKind::Info,
-        format!(
-            "Setting sparse checkout for {} plugin paths",
-            sparse_paths.len()
-        ),
+    info!(
+        "Metadata downloaded. Setting up sparse checkout for {} plugin paths",
+        sparse_paths.len()
     );
-
-    let output = Command::new("git")
+    let output = cmd!["git", "sparse-checkout", "set"]
         .current_dir(&temp_path)
-        .arg("sparse-checkout")
-        .arg("set")
         .args(&sparse_paths)
         .output()?;
 
@@ -159,125 +112,70 @@ pub fn clone_plugin_folders(
     let status = output.status;
 
     if !stdout.is_empty() {
-        add_log(LogKind::Info, format!("[git sparse-checkout]: {}", stdout));
+        info!("[git sparse-checkout]: {}", stdout);
     }
 
     if !stderr.is_empty() {
-        add_log(LogKind::Error, format!("[git sparse-checkout]: {}", stderr));
+        error!("[git sparse-checkout]: {}", stderr);
     }
 
     if !status.success() {
         // Clean up the temporary directory if sparse-checkout fails
-        add_log(
-            LogKind::Info,
-            format!(
-                "Cleaning up after failed sparse-checkout: {}",
-                temp_path.display()
-            ),
+        info!(
+            "Cleaning up after failed sparse-checkout: {}",
+            temp_path.display()
         );
         let _ = fs::remove_dir_all(&temp_path);
-        return Err("Failed to set sparse-checkout".into());
+        return Err(app_err!("Failed to set sparse-checkout"));
     }
 
     // Check if the plugins directory exists
     let temp_plugins_dir = temp_path.join("flint-plugins").join(kind_str);
-    add_log(
-        LogKind::Info,
-        format!(
-            "Checking for plugins directory: {}",
-            temp_plugins_dir.display()
-        ),
+    info!(
+        "Checking for plugins directory: {}",
+        temp_plugins_dir.display()
     );
 
     if !temp_plugins_dir.exists() {
-        add_log(
-            LogKind::Error,
-            format!(
-                "Plugins directory not found: {}",
-                temp_plugins_dir.display()
-            ),
-        );
-        let _ = fs::remove_dir_all(&temp_path);
-        return Err(format!(
+        error!(
             "Plugins directory not found: {}",
             temp_plugins_dir.display()
-        )
-        .into());
+        );
+        _ = fs::remove_dir_all(&temp_path).map_err(|e| {
+            app_err!(
+                "Failed to clean up temporary directory.\nError message: {}",
+                e
+            )
+        });
+        return Err(app_err!(
+            "Plugins directory not found: {}",
+            temp_plugins_dir.display()
+        ));
     }
-
-    add_log(
-        LogKind::Info,
-        format!(
-            "Found plugins directory, copying {} plugins",
-            plugin_ids.len()
-        ),
-    );
 
     // Copy each requested plugin to the final destination
     for id in &plugin_ids {
         let src_plugin_path = temp_plugins_dir.join(id);
         let dest_plugin_path = kind_path.join(id);
 
-        add_log(LogKind::Info, format!("Processing plugin: {}", id));
-
         if src_plugin_path.exists() {
             // Remove the destination plugin if it already exists
             if dest_plugin_path.exists() {
-                add_log(
-                    LogKind::Info,
-                    format!("Removing existing plugin: {}", dest_plugin_path.display()),
-                );
                 fs::remove_dir_all(&dest_plugin_path)?;
-                add_log(
-                    LogKind::Info,
-                    format!("Removed existing plugin: {}", dest_plugin_path.display()),
-                );
             }
 
             // Copy the plugin directory recursively
-            add_log(
-                LogKind::Info,
-                format!(
-                    "Copying plugin from {} to {}",
-                    src_plugin_path.display(),
-                    dest_plugin_path.display()
-                ),
-            );
             copy_dir_all(&src_plugin_path, &dest_plugin_path)?;
-            add_log(
-                LogKind::Info,
-                format!(
-                    "Copied plugin from {} to {}",
-                    src_plugin_path.display(),
-                    dest_plugin_path.display()
-                ),
-            );
         } else {
-            add_log(
-                LogKind::Warn,
-                format!("Plugin not found: {}", src_plugin_path.display()),
-            );
+            warn!("Plugin not found: {}", src_plugin_path.display());
         }
     }
 
     // Clean up the temporary directory
-    add_log(
-        LogKind::Info,
-        format!("Cleaning up temporary directory: {}", temp_path.display()),
-    );
+    info!("Cleaning up temporary directory: {}", temp_path.display());
     fs::remove_dir_all(&temp_path)?;
-    add_log(
-        LogKind::Info,
-        format!("Removed temporary directory: {}", temp_path.display()),
-    );
 
-    add_log(
-        LogKind::Info,
-        format!(
-            "Successfully extracted plugin folders to {}",
-            kind_path.display()
-        ),
-    );
+    success!("Successfully downloaded {} plugins", kind_path.display());
 
     Ok(kind_path)
 }
@@ -307,56 +205,32 @@ fn copy_dir_all(src: &Path, dst: &Path) -> Result<(), Box<dyn Error>> {
 
 // Example usage
 pub fn download_plugins(kind: PluginKind, ids: Vec<&String>) -> Result<(), Box<dyn Error>> {
-    add_log(
-        LogKind::Info,
-        format!(
-            "Starting download of {} plugins for {}",
-            ids.len(),
-            kind.to_string()
-        ),
+    info!(
+        "Starting download of {} {} plugins",
+        ids.len(),
+        kind.to_string()
     );
     let repo_url = "https://github.com/skadewdl3/flint";
-    add_log(LogKind::Info, format!("Using repository URL: {}", repo_url));
+    info!("Source repository: {}", repo_url);
     clone_plugin_folders(repo_url, kind.clone(), ids)?;
-    add_log(
-        LogKind::Info,
-        format!("Completed downloading {} plugins", kind.to_string()),
-    );
+    success!("Completed downloading {} plugins", kind.to_string());
     Ok(())
 }
 
 pub fn download_plugins_from_config(toml: &Config) -> Result<(), Box<dyn Error>> {
-    add_log(
-        LogKind::Info,
-        "Loading configuration from flint.toml".to_string(),
-    );
+    info!("Loading configuration from flint.toml");
 
     let linter_ids: Vec<&String> = toml.rules.keys().collect();
     let tester_ids: Vec<&String> = toml.tests.keys().collect();
     let ci_ids: Vec<&String> = toml.ci.keys().collect();
     let report_ids: Vec<&String> = toml.report.keys().collect();
 
-    add_log(
-        LogKind::Info,
-        format!("Found {} test plugins in configuration", tester_ids.len()),
-    );
-    add_log(
-        LogKind::Info,
-        format!("Found {} lint plugins in configuration", linter_ids.len()),
-    );
-    add_log(
-        LogKind::Info,
-        format!("Found {} CI plugins in configuration", ci_ids.len()),
-    );
-    add_log(
-        LogKind::Info,
-        format!("Found {} report plugins in configuration", report_ids.len()),
-    );
+    info!("Found {} test plugins in configuration", tester_ids.len());
+    info!("Found {} lint plugins in configuration", linter_ids.len());
+    info!("Found {} CI plugins in configuration", ci_ids.len());
+    info!("Found {} report plugins in configuration", report_ids.len());
 
-    add_log(
-        LogKind::Info,
-        "Starting download of all configured plugins".to_string(),
-    );
+    info!("Starting download of all configured plugins");
     if tester_ids.len() > 0 {
         download_plugins(PluginKind::Test, tester_ids)?;
     }
@@ -369,10 +243,7 @@ pub fn download_plugins_from_config(toml: &Config) -> Result<(), Box<dyn Error>>
     if report_ids.len() > 0 {
         download_plugins(PluginKind::Report, report_ids)?;
     }
-    add_log(
-        LogKind::Info,
-        "All plugins downloaded successfully".to_string(),
-    );
+    success!("All plugins downloaded successfully");
 
     Ok(())
 }

--- a/flint/src/util/plugin/download.rs
+++ b/flint/src/util/plugin/download.rs
@@ -69,7 +69,7 @@ pub fn clone_plugin_folders(
     ]
     .output()?;
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    let _stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     let status = output.status;
 
@@ -78,7 +78,7 @@ pub fn clone_plugin_folders(
             "Cleaning up temporary directory after failed clone: {}",
             temp_path.display()
         );
-        fs::remove_dir_all(&temp_path).map_err(|e| {
+        _ = fs::remove_dir_all(&temp_path).map_err(|e| {
             app_err!("Failed to remove temporary directory: {}", e);
         });
 

--- a/flint/src/util/plugin/find.rs
+++ b/flint/src/util/plugin/find.rs
@@ -1,7 +1,7 @@
 use super::{Plugin, PluginDetails, PluginKind};
 use crate::app::AppResult;
 use crate::util::toml::Config;
-use crate::{app_err, debug, error};
+use crate::{debug, error};
 use directories::ProjectDirs;
 use mlua::{Function, Lua, LuaSerdeExt};
 use std::{

--- a/flint/src/util/plugin/mod.rs
+++ b/flint/src/util/plugin/mod.rs
@@ -1,8 +1,5 @@
 use super::toml::Config;
-use crate::{
-    app::{AppError, AppResult},
-    widgets::logs::{add_log, LogKind},
-};
+use crate::app::{AppError, AppResult};
 
 pub mod find;
 pub mod helpers;

--- a/flint/src/util/toml.rs
+++ b/flint/src/util/toml.rs
@@ -20,8 +20,8 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn load(path: PathBuf) -> AppResult<Self> {
-        let toml_str = std::fs::read_to_string(path)?;
+    pub fn load(path: &PathBuf) -> AppResult<Self> {
+        let toml_str = std::fs::read_to_string(&path)?;
         let config: Config = toml::from_str(&toml_str)?;
         Ok(config)
     }

--- a/flint/src/widgets/logs.rs
+++ b/flint/src/widgets/logs.rs
@@ -6,19 +6,8 @@ use ratatui::{
     style::{Color, Style},
     widgets::{Block, Padding, Paragraph, StatefulWidget, Widget},
 };
-use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
-#[derive(Copy, Clone, Debug, Default)]
-pub enum LogKind {
-    #[default]
-    Info,
-    Success,
-    Error,
-    Warn,
-    Debug,
-}
-
-pub static LOGS: RwLock<Vec<(LogKind, String)>> = RwLock::new(vec![]);
+use crate::util::logs::{get_logs, LogKind};
 
 // Define a state to keep track of scrolling position
 #[derive(Debug, Clone, Copy)]
@@ -61,40 +50,6 @@ impl LogsState {
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct LogsWidget;
-
-pub fn get_logs() -> Result<
-    RwLockReadGuard<'static, Vec<(LogKind, String)>>,
-    std::sync::PoisonError<RwLockReadGuard<'static, Vec<(LogKind, String)>>>,
-> {
-    LOGS.read()
-}
-
-pub fn get_logs_mut() -> Result<
-    RwLockWriteGuard<'static, Vec<(LogKind, String)>>,
-    std::sync::PoisonError<RwLockWriteGuard<'static, Vec<(LogKind, String)>>>,
-> {
-    LOGS.write()
-}
-
-pub fn add_log(kind: LogKind, message: String) {
-    use std::fs::OpenOptions;
-    use std::io::Write;
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open("logs.txt")
-        .unwrap();
-    let prefix = match kind {
-        LogKind::Info => "[info]:",
-        LogKind::Success => "[success]:",
-        LogKind::Error => "[error]:",
-        LogKind::Warn => "[warn]:",
-        LogKind::Debug => "[debug]:",
-    };
-    let log = format!("{} {}", prefix, message);
-    writeln!(file, "{}", log).unwrap();
-    get_logs_mut().unwrap().push((kind, log));
-}
 
 fn get_style(kind: &LogKind) -> Style {
     Style::default().fg(match kind {

--- a/logs.txt
+++ b/logs.txt
@@ -258,3 +258,7 @@ Updating files:  28% (2/7)Updating files:  42% (3/7)Updating files:  57% (4/7)
 }
 [warn]: Skipping installation of plugins due to --no-install flag
 [success]: Generated github-actions config successfully
+[success]: Generated github-actions config successfully
+[success]: Generated github-actions config successfully
+[info]: "/home/skadewdl3/Projects/flint/flint-tests/js/.flint"
+[success]: Generated github-actions config successfully

--- a/logs.txt
+++ b/logs.txt
@@ -256,3 +256,5 @@ Updating files:  28% (2/7)Updating files:  42% (3/7)Updating files:  57% (4/7)
   "stderr": "",
   "success": true
 }
+[warn]: Skipping installation of plugins due to --no-install flag
+[success]: Generated github-actions config successfully

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
 CONFIG_PATH=flint-tests/js/flint.toml
 PLUGINS_DIR=flint-plugins
-target/debug/flint --no-install --config-path $CONFIG_PATH --plugins-dir $PLUGINS_DIR  generate
+cargo run -- --no-install --config-path $CONFIG_PATH --plugins-dir $PLUGINS_DIR  generate

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,3 @@
-cd flint-tests/js
-../../target/debug/flint generate
+CONFIG_PATH=flint-tests/js/flint.toml
+PLUGINS_DIR=flint-plugins
+target/debug/flint --no-install --config-path $CONFIG_PATH --plugins-dir $PLUGINS_DIR  generate


### PR DESCRIPTION
1. Improved error handling and logging
2. Added some flags which user can set (and we can use to make dev easier) like 
  - --no-install: Skips installation of plugins
  - --plugin-dir: Allows specifying location to flint-plugins directory
  - --config-path: Allows specifing path to flint.toml